### PR TITLE
Fix json syntax errors.

### DIFF
--- a/diaspora.json
+++ b/diaspora.json
@@ -17,6 +17,6 @@
   "Build":
   [
     {"command": "voc -s", "file": "src/diasporadb.Mod"},
-    }"command": "voc -s", "file": "src/diasporaPost.Mod"}
+    {"command": "voc -s", "file": "src/diasporaPost.Mod"}
   ]
 }

--- a/strutils2.json
+++ b/strutils2.json
@@ -23,6 +23,6 @@
   "Build":
     [
      {"Command": "voc -s", "File": "strTypes.Mod"},
-     {"Command": "voc -s", "File": "strUtils.Mod"},
+     {"Command": "voc -s", "File": "strUtils.Mod"}
     ]
 }

--- a/test_server.json
+++ b/test_server.json
@@ -14,7 +14,7 @@
     "lists": "0.1",
     "Internet":"0.1",
     "time": "0.1",
-    "fifo": "0.1",
+    "fifo": "0.1"
   },
   "Build":
   [


### PR DESCRIPTION
I was using the jq json query tool to pull values of the json files in vipackTree but it told me that diaspora.json, strutils2.json, and test_server.json had syntax errors, so I fixed them.