### PR TITLE
General Improvements to vipatsar and preparation for the upcoming upgrade

### DIFF
--- a/Bron-Dijkstra-Strings.json
+++ b/Bron-Dijkstra-Strings.json
@@ -1,16 +1,17 @@
 {
-  "Package": "Bron-Dijkstra-Strings",
-  "Author":  "noch",
-  "License": "GPL-3",
-  "Version": "0.1.0",
-  "Remote":
-    {
+  "package": "Bron-Dijkstra-Strings",
+  "author": "noch",
+  "license": "GPL-3",
+  "version": "0.1.0",
+  "remote": {
     "type": "git",
     "path": "https://github.com/norayr/Bron-Dijkstra-Strings",
-    "tag" : "0.1.0"
-    },
-   "Build":
-   [
-    {"command": "voc -s", "file": "bdStrings.Mod"}
-   ]
+    "tag": "0.1.0"
+  },
+  "build": [
+    {
+      "command": "voc -s",
+      "file": "bdStrings.Mod"
+    }
+  ]
 }

--- a/Bron-Dijkstra-Strings.json
+++ b/Bron-Dijkstra-Strings.json
@@ -2,12 +2,12 @@
   "Package": "Bron-Dijkstra-Strings",
   "Author":  "noch",
   "License": "GPL-3",
-  "Version": "0.1",
+  "Version": "0.1.0",
   "Remote":
     {
     "type": "git",
     "path": "https://github.com/norayr/Bron-Dijkstra-Strings",
-    "tag" : "0.1"
+    "tag" : "0.1.0"
     },
    "Build":
    [

--- a/Bron-Dijkstra-Strings/Bron-Dijkstra-Strings-0.1.0.vipakfile
+++ b/Bron-Dijkstra-Strings/Bron-Dijkstra-Strings-0.1.0.vipakfile
@@ -1,0 +1,17 @@
+NAME      = Bron-Dijkstra-Strings
+VERSION   = 0.1.0
+
+AUTHOR    = noch
+LICENSE   = GPL-3
+
+REMOTE    = git https://github.com/norayr/Bron-Dijkstra-Strings 0.1.0
+
+DEPS      = 
+
+RUN       = 
+MAIN      = 
+BUILD     = voc -s bdStrings.Mod
+
+TEST_RUN  = 
+TEST_MAIN = 
+TEST      = 

--- a/Internet.json
+++ b/Internet.json
@@ -2,16 +2,16 @@
   "Package": "Internet",
   "Author":  "noch",
   "License": "GPL-3",
-  "Version": "0.1",
+  "Version": "0.1.0",
   "Remote":
     {
     "type": "git",
     "path": "https://github.com/norayr/Internet",
-    "tag" : "0.1"
+    "tag" : "0.1.0"
     },
   "Dependencies":
     {
-    "time": "0.1"
+    "time": "0.1.0"
     },
    "Build": [
      {"command": "voc -s", "file": "src/netTypes.Mod"},

--- a/Internet.json
+++ b/Internet.json
@@ -1,26 +1,48 @@
 {
-  "Package": "Internet",
-  "Author":  "noch",
-  "License": "GPL-3",
-  "Version": "0.1.0",
-  "Remote":
-    {
+  "package": "Internet",
+  "author": "noch",
+  "license": "GPL-3",
+  "version": "0.1.0",
+  "remote": {
     "type": "git",
     "path": "https://github.com/norayr/Internet",
-    "tag" : "0.1.0"
-    },
-  "Dependencies":
-    {
+    "tag": "0.1.0"
+  },
+  "dependencies": {
     "time": "0.1.0"
+  },
+  "build": [
+    {
+      "command": "voc -s",
+      "file": "src/netTypes.Mod"
     },
-   "Build": [
-     {"command": "voc -s", "file": "src/netTypes.Mod"},
-     {"command": "voc -s", "file": "src/netdb.Mod"},
-     {"command": "voc -s", "file": "src/netSockets.Mod"},
-     {"command": "voc -s", "file": "src/Internet.Mod"},
-     {"command": "voc -s", "file": "src/netForker.Mod"},
-     {"command": "voc -s", "file": "src/server.Mod"},
-     {"command": "voc -m", "file": "tst/testClient.Mod"},
-     {"command": "voc -m", "file": "tst/testServer.Mod"}
-   ]
+    {
+      "command": "voc -s",
+      "file": "src/netdb.Mod"
+    },
+    {
+      "command": "voc -s",
+      "file": "src/netSockets.Mod"
+    },
+    {
+      "command": "voc -s",
+      "file": "src/Internet.Mod"
+    },
+    {
+      "command": "voc -s",
+      "file": "src/netForker.Mod"
+    },
+    {
+      "command": "voc -s",
+      "file": "src/server.Mod"
+    },
+    {
+      "command": "voc -m",
+      "file": "tst/testClient.Mod"
+    },
+    {
+      "command": "voc -m",
+      "file": "tst/testServer.Mod"
+    }
+  ]
 }

--- a/Internet/Internet-0.1.0.vipakfile
+++ b/Internet/Internet-0.1.0.vipakfile
@@ -1,0 +1,17 @@
+NAME      = Internet
+VERSION   = 0.1.0
+
+AUTHOR    = noch
+LICENSE   = GPL-3
+
+REMOTE    = git https://github.com/norayr/Internet 0.1.0
+
+DEPS      = time:0.1.0
+
+RUN       = 
+MAIN      = 
+BUILD     = voc -s src/netTypes.Mod;voc -s src/netdb.Mod;voc -s src/netSockets.Mod;voc -s src/Internet.Mod;voc -s src/netForker.Mod;voc -s src/server.Mod;voc -m tst/testClient.Mod;voc -m tst/testServer.Mod
+
+TEST_RUN  = 
+TEST_MAIN = 
+TEST      = 

--- a/_Scripts/convert_vipakfile.sh
+++ b/_Scripts/convert_vipakfile.sh
@@ -1,48 +1,43 @@
 #!/bin/sh
+# convert_vipakfile.sh: Convert JSON vipakfile to plain-text .vipakfile format
 
-# convert_vipakfile.sh: Convert old JSON vipakfile to new plain-text format
 
-# Program name and version
 PROGNAME=${0##*/}
 VERSION="0.1.0"
 
-# Colors for output
 COLOUR_SET_R="\033[0;31m"
 COLOUR_SET_G="\033[0;32m"
 COLOUR_SET_B="\033[0;34m"
 COLOUR_END="\033[0m"
 
-# Error, info, and action print functions
 perror() {
   printf "${COLOUR_SET_R}[-] ${COLOUR_END}%s\n" "$@" >&2
   exit 1
 }
 
 pinfo() {
-  printf "${COLOUR_SET_B}[+] ${COLOUR_END}%s\n" "$@" >&2
+  printf "${COLOUR_SET_B}[*] ${COLOUR_END}%s\n" "$@" >&2
 }
 
 paction() {
-  printf "${COLOUR_SET_G}[*] ${COLOUR_END}%s\n" "$@" >&2
+  printf "${COLOUR_SET_G}[+] ${COLOUR_END}%s\n" "$@" >&2
 }
 
-# Usage message
 usage() {
   cat <<EOF
 Usage: $PROGNAME [-o <output_file> | -c] [-f] [--verbose] <input_json_file>
-  Convert old JSON vipakfile to new plain-text format.
+  Convert JSON vipakfile to new plain-text .vipakfile format.
   -o <output_file>  Write to specified file (default: stdout)
-  -c                Write to <Package>-<Version>.vipakfile
+  -c                Write to <package>-<version>.vipakfile
   -f                Force overwrite of existing output file
   --verbose         Print debug information about extracted fields
 EOF
   exit 0
 }
 
-# Check dependencies
 command -v jq >/dev/null 2>&1 || perror "jq is required but not found"
+command -v sed >/dev/null 2>&1 || perror "sed is required but not found"
 
-# Parse arguments
 output_mode="stdout"
 output_file=""
 input_file=""
@@ -83,44 +78,88 @@ done
 [ -f "$input_file" ] || perror "Input file '$input_file' not found"
 [ -r "$input_file" ] || perror "Input file '$input_file' is not readable"
 
-# Validate JSON
 jq -e . "$input_file" >/dev/null 2>&1 || perror "Invalid JSON in $input_file"
 
-# Extract fields using jq
 paction "Parsing $input_file"
-name=$(jq -r '.Package // ""' "$input_file")
-version=$(jq -r '.Version // ""' "$input_file")
-author=$(jq -r '.Author // ""' "$input_file")
-license=$(jq -r '.License // ""' "$input_file")
+name=$(jq -r '.package // ""' "$input_file")
+version=$(jq -r '.version // ""' "$input_file")
+author=$(jq -r '.author // ""' "$input_file")
+license=$(jq -r '.license // ""' "$input_file")
 
-# Validate required fields
-[ -z "$name" ] && perror "Package name is required"
-[ -z "$version" ] && perror "Version is required"
+[ -z "$name" ] && perror "package field is required"
+[ -z "$version" ] && perror "version field is required"
 
-# Extract Remote (type, path, tag)
-remote_type=$(jq -r '.Remote.type // ""' "$input_file")
-remote_path=$(jq -r '.Remote.path // ""' "$input_file")
-remote_tag=$(jq -r '.Remote.tag // ""' "$input_file")
+# Extract Remote (handle git and https)
+remote_type=$(jq -r '.remote.type // ""' "$input_file")
 remote=""
-if [ -n "$remote_type" ] && [ -n "$remote_path" ] && [ -n "$remote_tag" ]; then
-  remote="$remote_type $remote_path $remote_tag"
-fi
+case "$remote_type" in
+  git)
+    remote_url=$(jq -r '.remote.url // .remote.path // ""' "$input_file")
+    remote_tag=$(jq -r '.remote.tag // ""' "$input_file")
+    if [ -z "$remote_url" ]; then
+      perror "remote.url or remote.path required for remote.type=git"
+    fi
+    remote="git $remote_url"
+    [ -n "$remote_tag" ] && remote="$remote $remote_tag"
+    ;;
+  https)
+    # Extract remote.files as raw data
+    remote_files=$(jq -r '.remote.files // [] | map(
+      [.url, .authtype // "None", .authcredentials.user // "", .authcredentials.password // "", .md5 // ""] | join("\t")
+    ) | join("\n")' "$input_file") || {
+      perror "Failed to process remote.files in $input_file"
+      exit 1
+    }
+    if [ -z "$remote_files" ]; then
+      perror "remote.files required for remote.type=https"
+    fi
+    # Process each file entry in shell
+    remote_files_out=""
+    IFS='
+'
+    for file in $remote_files; do
+      url=$(echo "$file" | cut -f1)
+      authtype=$(echo "$file" | cut -f2)
+      user=$(echo "$file" | cut -f3)
+      password=$(echo "$file" | cut -f4)
+      md5=$(echo "$file" | cut -f5)
+      if [ "$authtype" = "BasicAuth" ]; then
+        if [ -z "$user" ] || [ -z "$password" ]; then
+          perror "Missing authcredentials.user or authcredentials.password for BasicAuth in $input_file"
+        fi
+        # Insert user:password@ after protocol
+        auth_url=$(echo "$url" | sed -E "s,^(https?://),\1$user:$password@,")
+        entry="$auth_url md5,$md5"
+      else
+        entry="$url md5,$md5"
+      fi
+      if [ -z "$remote_files_out" ]; then
+        remote_files_out="$entry"
+      else
+        remote_files_out="$remote_files_out;$entry"
+      fi
+    done
+    unset IFS
+    remote="https $remote_files_out"
+    ;;
+  "")
+    : # Empty remote is valid
+    ;;
+  *)
+    perror "Unsupported remote.type: $remote_type. Only 'git' or 'https' allowed"
+    ;;
+esac
 
-# Extract Dependencies as space-separated list
-deps=$(jq -r 'if .Dependencies then .Dependencies | to_entries | map("\(.key):\(.value)") | join(" ") else "" end' "$input_file")
-
-# Extract Build commands as semicolon-separated list
-build=$(jq -r '.Build | map(.command + " " + .file) | join(";")' "$input_file")
+deps=$(jq -r 'if .dependencies then .dependencies | to_entries | map("\(.key):\(.value)") | join(" ") else "" end' "$input_file")
+build=$(jq -r '.build // [] | map(.command + " " + .file) | join(";")' "$input_file")
 [ "$build" = "null" ] && build=""
 
-# Default empty fields
 run=""
 main=""
 test_run=""
 test_main=""
 test_cmd=""
 
-# Verbose output
 [ -n "$verbose" ] && {
   pinfo "Extracted fields:"
   pinfo "  NAME=$name"
@@ -137,7 +176,6 @@ test_cmd=""
   pinfo "  TEST=$test_cmd"
 }
 
-# Generate vipakfile content
 vipakfile_content=$(cat <<EOF
 NAME      = $name
 VERSION   = $version
@@ -159,7 +197,6 @@ TEST      = $test_cmd
 EOF
 )
 
-# Handle output
 case "$output_mode" in
   stdout)
     paction "Writing to stdout"

--- a/_Scripts/convert_vipatsar.sh
+++ b/_Scripts/convert_vipatsar.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-
 # convert_vipatsar.sh: Convert old JSON vipakfiles to new plain-text format with
 # proper file naming and versioning using convert_vipakfile.sh
 
@@ -35,8 +34,9 @@ do
   pinfo "Working on ${port}"
   cd $dir
   paction "Converting ${port}.json"
-  ../convert_vipakfile.sh -c "${port}.json"
+  ../_Scripts/convert_vipakfile.sh -c "../${port}.json"
   pinfo "Conversion done"
 
   cd - >/dev/null || return
 done
+

--- a/_Scripts/to_lower.sh
+++ b/_Scripts/to_lower.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+# to_lower.sh: Convert JSON keys to lowercase, preserving dependencies subkeys
+
+
+PROGNAME=${0##*/}
+
+COLOUR_SET_R="\033[0;31m"
+COLOUR_SET_G="\033[0;32m"
+COLOUR_SET_B="\033[0;34m"
+COLOUR_END="\033[0m"
+
+perror() {
+  printf "${COLOUR_SET_R}[-] ${COLOUR_END}%s\n" "$@" >&2
+  exit 1
+}
+
+pinfo() {
+  printf "${COLOUR_SET_B}[*] ${COLOUR_END}%s\n" "$@" >&2
+}
+
+paction() {
+  printf "${COLOUR_SET_G}[+] ${COLOUR_END}%s\n" "$@" >&2
+}
+
+usage() {
+  cat <<EOF
+Usage: $PROGNAME [--all] [file ...]
+  Convert JSON keys to lowercase, preserving dependencies subkeys.
+  --all    Process all .json files in current directory
+  file     Process specified JSON files
+EOF
+  exit 0
+}
+
+command -v jq >/dev/null 2>&1 || perror "jq is required but not found"
+
+if [ $# -eq 0 ]; then
+  usage
+fi
+
+if [ "$1" = "--all" ]; then
+  files=$(ls *.json 2>/dev/null)
+  [ -z "$files" ] && perror "No JSON files found in current directory"
+else
+  files="$*"
+  for file in $files; do
+    [ -f "$file" ] || perror "File $file not found"
+    case "$file" in
+      *.json) : ;;
+      *) perror "File $file is not a .json file" ;;
+    esac
+  done
+fi
+
+for file in $files; do
+  [ -r "$file" ] || perror "File $file is not readable"
+  paction "Converting keys to lowercase in $file"
+  tmpfile=$(mktemp)
+  jq '
+    def to_lower:
+      if type == "object" then
+        with_entries(
+          .key |= (if . == "dependencies" then . else ascii_downcase end)
+        ) | map_values(to_lower)
+      elif type == "array" then
+        map(to_lower)
+      else
+        .
+      end;
+    to_lower
+  ' "$file" > "$tmpfile" 2>/dev/null || {
+    rm -f "$tmpfile"
+    perror "Failed to process $file with jq"
+  }
+  mv "$tmpfile" "$file" || perror "Failed to overwrite $file"
+  pinfo "Processed $file"
+done
+
+pinfo "All files processed successfully"

--- a/_Scripts/validate_json.sh
+++ b/_Scripts/validate_json.sh
@@ -89,10 +89,6 @@ validate_json() {
       fi
     fi
   fi
-  if jq -e '.dependencies | type != "object"' "$json" >/dev/null 2>/dev/null; then
-    perror "$json invalid dependencies field (must be object)"
-    errors=$((errors + 1))
-  fi
   if ! jq -e '.build | type == "array"' "$json" >/dev/null 2>/dev/null; then
     perror "$json invalid build field (must be array)"
     errors=$((errors + 1))

--- a/_Scripts/validate_json.sh
+++ b/_Scripts/validate_json.sh
@@ -1,0 +1,145 @@
+#!/bin/sh
+# validate_json.sh: Validate JSON vipakfiles
+
+
+PROGNAME=${0##*/}
+
+COLOUR_SET_R="\033[0;31m"
+COLOUR_SET_G="\033[0;32m"
+COLOUR_SET_B="\033[0;34m"
+COLOUR_END="\033[0m"
+
+perror() {
+  printf "${COLOUR_SET_R}[-] ${COLOUR_END}%s\n" "$@" >&2
+  exit 1
+}
+
+pinfo() {
+  printf "${COLOUR_SET_B}[*] ${COLOUR_END}%s\n" "$@" >&2
+}
+
+paction() {
+  printf "${COLOUR_SET_G}[+] ${COLOUR_END}%s\n" "$@" >&2
+}
+
+usage() {
+  cat <<EOF
+Usage: $PROGNAME [--all] [file ...]
+  Validate JSON vipakfiles.
+  --all    Validate all .json files in current directory
+  file     Validate specified JSON files
+EOF
+  exit 0
+}
+
+command -v jq >/dev/null 2>&1 || perror "jq is required but not found"
+
+validate_json() {
+  json="$1"
+  errors=0
+  if ! jq -e . "$json" >/dev/null 2>/dev/null; then
+    perror "$json is not valid JSON"
+    errors=$((errors + 1))
+  fi
+  if ! jq -e '.package | type == "string" and length > 0' "$json" >/dev/null 2>/dev/null; then
+    perror "$json missing or invalid package field"
+    errors=$((errors + 1))
+  fi
+  if ! jq -e '.version | type == "string" and length > 0' "$json" >/dev/null 2>/dev/null; then
+    perror "$json missing or invalid version field"
+    errors=$((errors + 1))
+  fi
+  if ! jq -e '.author | type == "string"' "$json" >/dev/null 2>/dev/null; then
+    perror "$json invalid author field (must be string)"
+    errors=$((errors + 1))
+  fi
+  if ! jq -e '.license | type == "string"' "$json" >/dev/null 2>/dev/null; then
+    perror "$json invalid license field (must be string)"
+    errors=$((errors + 1))
+  fi
+  if jq -e '.remote | type == "object"' "$json" >/dev/null 2>/dev/null; then
+    if ! jq -e '.remote.type | type == "string" and (. == "" or . == "git" or . == "https")' "$json" >/dev/null 2>/dev/null; then
+      perror "$json invalid remote.type (must be empty, 'git', or 'https')"
+      errors=$((errors + 1))
+    fi
+    if jq -e '.remote.type == "git"' "$json" >/dev/null 2>/dev/null; then
+      if ! jq -e '.remote.url // .remote.path | type == "string" and length > 0' "$json" >/dev/null 2>/dev/null; then
+        perror "$json with remote.type=git missing or invalid remote.url or remote.path"
+        errors=$((errors + 1))
+      fi
+      if jq -e '.remote.tag | type != "string"' "$json" >/dev/null 2>/dev/null; then
+        perror "$json invalid remote.tag (must be string)"
+        errors=$((errors + 1))
+      fi
+    fi
+    if jq -e '.remote.type == "https"' "$json" >/dev/null 2>/dev/null; then
+      if ! jq -e '.remote.files | type == "array" and length > 0' "$json" >/dev/null 2>/dev/null; then
+        perror "$json with remote.type=https missing or empty remote.files array"
+        errors=$((errors + 1))
+      fi
+      if ! jq -e '.remote.files[] | select(type == "object" and (.url | test("^(http|https)://") and .md5 | test("^[0-9a-f]{32}$")) and (.authtype != "BasicAuth" or (.authcredentials.user | type == "string" and length > 0 and .authcredentials.password | type == "string" and length > 0)))' "$json" >/dev/null 2>/dev/null; then
+        jq -r '.remote.files[] | select(type != "object" or (.url | not or (.url | test("^(http|https)://") | not) or (.md5 | not or (.md5 | test("^[0-9a-f]{32}$") | not)) or (.authtype == "BasicAuth" and (.authcredentials.user | not or (.authcredentials.user | type != "string" or length == 0) or .authcredentials.password | not or (.authcredentials.password | type != "string" or length == 0)))) | .url // "missing"' "$json" 2>/dev/null | while read -r url; do
+          perror "$json has invalid remote.files entry (url: $url, must be object with valid URL, 32-char MD5, and for BasicAuth, non-empty user/password)"
+          errors=$((errors + 1))
+        done
+        if [ $? -ne 0 ]; then
+          perror "$json remote.files validation failed due to jq error"
+          errors=$((errors + 1))
+        fi
+      fi
+    fi
+  fi
+  if jq -e '.dependencies | type != "object"' "$json" >/dev/null 2>/dev/null; then
+    perror "$json invalid dependencies field (must be object)"
+    errors=$((errors + 1))
+  fi
+  if ! jq -e '.build | type == "array"' "$json" >/dev/null 2>/dev/null; then
+    perror "$json invalid build field (must be array)"
+    errors=$((errors + 1))
+  fi
+  if ! jq -e '.build[] | select(type == "object" and .command | type == "string" and length > 0 and .file | type == "string" and length > 0)' "$json" >/dev/null 2>/dev/null; then
+    jq -r '.build[] | select(type != "object" or (.command | not or (.command | type != "string" or length == 0) or .file | not or (.file | type != "string" or length == 0))) | .file // "missing"' "$json" 2>/dev/null | while read -r file; do
+      perror "$json has invalid build entry (file: $file, must be object with non-empty command and file)"
+      errors=$((errors + 1))
+    done
+    if [ $? -ne 0 ]; then
+      perror "$json build validation failed due to jq error"
+      errors=$((errors + 1))
+    fi
+  fi
+  [ $errors -eq 0 ] && pinfo "$json is valid"
+  return $errors
+}
+
+errors=0
+if [ $# -eq 0 ]; then
+  usage
+fi
+
+if [ "$1" = "--all" ]; then
+  files=$(ls *.json 2>/dev/null)
+  [ -z "$files" ] && perror "No JSON files found in current directory"
+else
+  files="$*"
+  for file in $files; do
+    [ -f "$file" ] || perror "File $file not found"
+    case "$file" in
+      *.json) : ;;
+      *) perror "File $file is not a .json file" ;;
+    esac
+  done
+fi
+
+for file in $files; do
+  paction "Validating $file"
+  validate_json "$file"
+  [ $? -ne 0 ] && errors=$((errors + 1))
+done
+
+if [ $errors -eq 0 ]; then
+  pinfo "All JSON files validated successfully"
+  exit 0
+else
+  perror "Validation failed with $errors error(s)"
+  exit 1
+fi

--- a/armscii.json
+++ b/armscii.json
@@ -2,12 +2,12 @@
   "Package": "Internet",
   "Author":  "noch",
   "License": "GPL-3",
-  "Version": "0.1",
+  "Version": "0.1.0",
   "Remote":
     {
     "type": "git",
     "path": "https://github.com/norayr/armscii",
-    "tag" : "0.1"
+    "tag" : "0.1.0"
     },
     "Build":
     [

--- a/armscii.json
+++ b/armscii.json
@@ -1,5 +1,5 @@
 {
-  "package": "Internet",
+  "package": "armscii",
   "author": "noch",
   "license": "GPL-3",
   "version": "0.1.0",

--- a/armscii.json
+++ b/armscii.json
@@ -1,16 +1,17 @@
 {
-  "Package": "Internet",
-  "Author":  "noch",
-  "License": "GPL-3",
-  "Version": "0.1.0",
-  "Remote":
-    {
+  "package": "Internet",
+  "author": "noch",
+  "license": "GPL-3",
+  "version": "0.1.0",
+  "remote": {
     "type": "git",
     "path": "https://github.com/norayr/armscii",
-    "tag" : "0.1.0"
-    },
-    "Build":
-    [
-      {"command": "voc -s", "file": "ArmsciiUTF.Mod"}
-    ]
+    "tag": "0.1.0"
+  },
+  "build": [
+    {
+      "command": "voc -s",
+      "file": "ArmsciiUTF.Mod"
+    }
+  ]
 }

--- a/armscii/Internet-0.1.0.vipakfile
+++ b/armscii/Internet-0.1.0.vipakfile
@@ -1,0 +1,17 @@
+NAME      = Internet
+VERSION   = 0.1.0
+
+AUTHOR    = noch
+LICENSE   = GPL-3
+
+REMOTE    = git https://github.com/norayr/armscii 0.1.0
+
+DEPS      = 
+
+RUN       = 
+MAIN      = 
+BUILD     = voc -s ArmsciiUTF.Mod
+
+TEST_RUN  = 
+TEST_MAIN = 
+TEST      = 

--- a/armscii/armscii-0.1.0.vipakfile
+++ b/armscii/armscii-0.1.0.vipakfile
@@ -1,4 +1,4 @@
-NAME      = Internet
+NAME      = armscii
 VERSION   = 0.1.0
 
 AUTHOR    = noch

--- a/armscii2.json
+++ b/armscii2.json
@@ -2,7 +2,7 @@
     "Package": "armscii2",
     "Author": "noch",
     "License": "GPL-3",
-    "Version": "0.1",
+    "Version": "0.1.0",
     "Remote": {
         "Type": "https",
         "Files": [

--- a/armscii2.json
+++ b/armscii2.json
@@ -1,21 +1,21 @@
 {
-    "Package": "armscii2",
-    "Author": "noch",
-    "License": "GPL-3",
-    "Version": "0.1.0",
-    "Remote": {
-        "Type": "https",
-        "Files": [
-            {
-                "URL": "https://norayr.am/vpk2/armscii/ArmsciiUTF.Mod",
-                "MD5": "14790276c48db775a5fee99a48525dd9"
-            }
-        ]
-    },
-    "Build": [
-        {
-            "Command": "voc -s",
-            "File": "ArmsciiUTF.Mod"
-        }
+  "package": "armscii2",
+  "author": "noch",
+  "license": "GPL-3",
+  "version": "0.1.0",
+  "remote": {
+    "type": "https",
+    "files": [
+      {
+        "url": "https://norayr.am/vpk2/armscii/ArmsciiUTF.Mod",
+        "md5": "14790276c48db775a5fee99a48525dd9"
+      }
     ]
+  },
+  "build": [
+    {
+      "command": "voc -s",
+      "file": "ArmsciiUTF.Mod"
+    }
+  ]
 }

--- a/armscii2/armscii2-0.1.0.vipakfile
+++ b/armscii2/armscii2-0.1.0.vipakfile
@@ -4,13 +4,13 @@ VERSION   = 0.1.0
 AUTHOR    = noch
 LICENSE   = GPL-3
 
-REMOTE    = 
+REMOTE    = https https://norayr.am/vpk2/armscii/ArmsciiUTF.Mod md5,14790276c48db775a5fee99a48525dd9
 
 DEPS      = 
 
 RUN       = 
 MAIN      = 
-BUILD     =  
+BUILD     = voc -s ArmsciiUTF.Mod
 
 TEST_RUN  = 
 TEST_MAIN = 

--- a/armscii2/armscii2-0.1.0.vipakfile
+++ b/armscii2/armscii2-0.1.0.vipakfile
@@ -1,0 +1,17 @@
+NAME      = armscii2
+VERSION   = 0.1.0
+
+AUTHOR    = noch
+LICENSE   = GPL-3
+
+REMOTE    = 
+
+DEPS      = 
+
+RUN       = 
+MAIN      = 
+BUILD     =  
+
+TEST_RUN  = 
+TEST_MAIN = 
+TEST      = 

--- a/base64.json
+++ b/base64.json
@@ -2,12 +2,12 @@
   "Package": "base64",
   "Author":  "noch",
   "License": "GPL-3",
-  "Version": "0.1",
+  "Version": "0.1.0",
   "Remote":
     {
     "type": "git",
     "path": "https://github.com/norayr/base64",
-    "tag" : "0.1"
+    "tag" : "0.1.0"
     },
   "Build":
   [

--- a/base64.json
+++ b/base64.json
@@ -1,16 +1,17 @@
 {
-  "Package": "base64",
-  "Author":  "noch",
-  "License": "GPL-3",
-  "Version": "0.1.0",
-  "Remote":
-    {
+  "package": "base64",
+  "author": "noch",
+  "license": "GPL-3",
+  "version": "0.1.0",
+  "remote": {
     "type": "git",
     "path": "https://github.com/norayr/base64",
-    "tag" : "0.1.0"
-    },
-  "Build":
-  [
-     {"command": "voc -s", "file": "src/Base64.Mod"}
+    "tag": "0.1.0"
+  },
+  "build": [
+    {
+      "command": "voc -s",
+      "file": "src/Base64.Mod"
+    }
   ]
 }

--- a/base64/base64-0.1.0.vipakfile
+++ b/base64/base64-0.1.0.vipakfile
@@ -1,0 +1,17 @@
+NAME      = base64
+VERSION   = 0.1.0
+
+AUTHOR    = noch
+LICENSE   = GPL-3
+
+REMOTE    = git https://github.com/norayr/base64 0.1.0
+
+DEPS      = 
+
+RUN       = 
+MAIN      = 
+BUILD     = voc -s src/Base64.Mod
+
+TEST_RUN  = 
+TEST_MAIN = 
+TEST      = 

--- a/cairo.json
+++ b/cairo.json
@@ -2,7 +2,7 @@
   "Package": "cairo",
   "Author": "une",
   "License": "GPL-3",
-  "Version": "0.1",
+  "Version": "0.1.0",
 
   "Remote": {
     "Type": "https",

--- a/cairo.json
+++ b/cairo.json
@@ -1,22 +1,22 @@
 {
-  "Package": "cairo",
-  "Author": "une",
-  "License": "GPL-3",
-  "Version": "0.1.0",
-
-  "Remote": {
-    "Type": "https",
-    "Files": [
+  "package": "cairo",
+  "author": "une",
+  "license": "GPL-3",
+  "version": "0.1.0",
+  "remote": {
+    "type": "https",
+    "files": [
       {
-        "URL": "https://codeberg.org/une/oberon-cairo/raw/commit/bca71235f8/Cairo.mod",
-        "AuthType": "None",
-        "MD5": "e6f3d616481b1c5da1c9eebdb2e75ae7"
+        "url": "https://codeberg.org/une/oberon-cairo/raw/commit/bca71235f8/Cairo.mod",
+        "authtype": "None",
+        "md5": "e6f3d616481b1c5da1c9eebdb2e75ae7"
       }
     ]
   },
-
-  "Build": [
-    {"Command": "voc -s", "File": "Cairo.mod"}
+  "build": [
+    {
+      "command": "voc -s",
+      "file": "Cairo.mod"
+    }
   ]
 }
-

--- a/cairo/cairo-0.1.0.vipakfile
+++ b/cairo/cairo-0.1.0.vipakfile
@@ -1,0 +1,17 @@
+NAME      = cairo
+VERSION   = 0.1.0
+
+AUTHOR    = une
+LICENSE   = GPL-3
+
+REMOTE    = 
+
+DEPS      = 
+
+RUN       = 
+MAIN      = 
+BUILD     =  
+
+TEST_RUN  = 
+TEST_MAIN = 
+TEST      = 

--- a/cairo/cairo-0.1.0.vipakfile
+++ b/cairo/cairo-0.1.0.vipakfile
@@ -4,13 +4,13 @@ VERSION   = 0.1.0
 AUTHOR    = une
 LICENSE   = GPL-3
 
-REMOTE    = 
+REMOTE    = https https://codeberg.org/une/oberon-cairo/raw/commit/bca71235f8/Cairo.mod md5,e6f3d616481b1c5da1c9eebdb2e75ae7
 
 DEPS      = 
 
 RUN       = 
 MAIN      = 
-BUILD     =  
+BUILD     = voc -s Cairo.mod
 
 TEST_RUN  = 
 TEST_MAIN = 

--- a/convert_vipakfile.sh
+++ b/convert_vipakfile.sh
@@ -1,0 +1,181 @@
+#!/bin/sh
+
+# convert_vipakfile.sh: Convert old JSON vipakfile to new plain-text format
+
+# Program name and version
+PROGNAME=${0##*/}
+VERSION="0.1.0"
+
+# Colors for output
+COLOUR_SET_R="\033[0;31m"
+COLOUR_SET_G="\033[0;32m"
+COLOUR_SET_B="\033[0;34m"
+COLOUR_END="\033[0m"
+
+# Error, info, and action print functions
+perror() {
+  printf "${COLOUR_SET_R}[-] ${COLOUR_END}%s\n" "$@" >&2
+  exit 1
+}
+
+pinfo() {
+  printf "${COLOUR_SET_B}[+] ${COLOUR_END}%s\n" "$@" >&2
+}
+
+paction() {
+  printf "${COLOUR_SET_G}[*] ${COLOUR_END}%s\n" "$@" >&2
+}
+
+# Usage message
+usage() {
+  cat <<EOF
+Usage: $PROGNAME [-o <output_file> | -c] [-f] [--verbose] <input_json_file>
+  Convert old JSON vipakfile to new plain-text format.
+  -o <output_file>  Write to specified file (default: stdout)
+  -c                Write to <Package>-<Version>.vipakfile
+  -f                Force overwrite of existing output file
+  --verbose         Print debug information about extracted fields
+EOF
+  exit 0
+}
+
+# Check dependencies
+command -v jq >/dev/null 2>&1 || perror "jq is required but not found"
+
+# Parse arguments
+output_mode="stdout"
+output_file=""
+input_file=""
+force_overwrite=""
+verbose=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -o)
+      [ $# -lt 2 ] && perror "Option -o requires an output file"
+      output_mode="file"
+      output_file="$2"
+      shift 2
+      ;;
+    -c)
+      output_mode="versioned"
+      shift
+      ;;
+    -f)
+      force_overwrite=1
+      shift
+      ;;
+    --verbose)
+      verbose=1
+      shift
+      ;;
+    -*)
+      perror "Unknown option: $1"
+      ;;
+    *)
+      [ -n "$input_file" ] && perror "Only one input file allowed"
+      input_file="$1"
+      shift
+      ;;
+  esac
+done
+
+[ -z "$input_file" ] && usage
+[ -f "$input_file" ] || perror "Input file '$input_file' not found"
+[ -r "$input_file" ] || perror "Input file '$input_file' is not readable"
+
+# Validate JSON
+jq -e . "$input_file" >/dev/null 2>&1 || perror "Invalid JSON in $input_file"
+
+# Extract fields using jq
+paction "Parsing $input_file"
+name=$(jq -r '.Package // ""' "$input_file")
+version=$(jq -r '.Version // ""' "$input_file")
+author=$(jq -r '.Author // ""' "$input_file")
+license=$(jq -r '.License // ""' "$input_file")
+
+# Validate required fields
+[ -z "$name" ] && perror "Package name is required"
+[ -z "$version" ] && perror "Version is required"
+
+# Extract Remote (type, path, tag)
+remote_type=$(jq -r '.Remote.type // ""' "$input_file")
+remote_path=$(jq -r '.Remote.path // ""' "$input_file")
+remote_tag=$(jq -r '.Remote.tag // ""' "$input_file")
+remote=""
+if [ -n "$remote_type" ] && [ -n "$remote_path" ] && [ -n "$remote_tag" ]; then
+  remote="$remote_type $remote_path $remote_tag"
+fi
+
+# Extract Dependencies as space-separated list
+deps=$(jq -r 'if .Dependencies then .Dependencies | to_entries | map("\(.key):\(.value)") | join(" ") else "" end' "$input_file")
+
+# Extract Build commands as semicolon-separated list
+build=$(jq -r '.Build | map(.command + " " + .file) | join(";")' "$input_file")
+[ "$build" = "null" ] && build=""
+
+# Default empty fields
+run=""
+main=""
+test_run=""
+test_main=""
+test_cmd=""
+
+# Verbose output
+[ -n "$verbose" ] && {
+  pinfo "Extracted fields:"
+  pinfo "  NAME=$name"
+  pinfo "  VERSION=$version"
+  pinfo "  AUTHOR=$author"
+  pinfo "  LICENSE=$license"
+  pinfo "  REMOTE=$remote"
+  pinfo "  DEPS=$deps"
+  pinfo "  BUILD=$build"
+  pinfo "  RUN=$run"
+  pinfo "  MAIN=$main"
+  pinfo "  TEST_RUN=$test_run"
+  pinfo "  TEST_MAIN=$test_main"
+  pinfo "  TEST=$test_cmd"
+}
+
+# Generate vipakfile content
+vipakfile_content=$(cat <<EOF
+NAME      = $name
+VERSION   = $version
+
+AUTHOR    = $author
+LICENSE   = $license
+
+REMOTE    = $remote
+
+DEPS      = $deps
+
+RUN       = $run
+MAIN      = $main
+BUILD     = $build
+
+TEST_RUN  = $test_run
+TEST_MAIN = $test_main
+TEST      = $test_cmd
+EOF
+)
+
+# Handle output
+case "$output_mode" in
+  stdout)
+    paction "Writing to stdout"
+    printf "%s\n" "$vipakfile_content"
+    ;;
+  file)
+    [ -z "$force_overwrite" ] && [ -f "$output_file" ] && perror "Output file '$output_file' already exists"
+    paction "Writing $output_file"
+    printf "%s\n" "$vipakfile_content" > "$output_file" 2>/dev/null || perror "Failed to write to '$output_file'"
+    pinfo "Conversion complete: $output_file"
+    ;;
+  versioned)
+    output_file="$name-$version.vipakfile"
+    [ -z "$force_overwrite" ] && [ -f "$output_file" ] && perror "Output file '$output_file' already exists"
+    paction "Writing $output_file"
+    printf "%s\n" "$vipakfile_content" > "$output_file" 2>/dev/null || perror "Failed to write to '$output_file'"
+    pinfo "Conversion complete: $output_file"
+    ;;
+esac

--- a/convert_vipatsar.sh
+++ b/convert_vipatsar.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+# convert_vipatsar.sh: Convert old JSON vipakfiles to new plain-text format with
+# proper file naming and versioning using convert_vipakfile.sh
+
+# Program name and version
+PROGNAME=${0##*/}
+VERSION="0.1.0"
+
+# Colors for output
+COLOUR_SET_R="\033[0;31m"
+COLOUR_SET_G="\033[0;32m"
+COLOUR_SET_B="\033[0;34m"
+COLOUR_END="\033[0m"
+
+# Error, info, and action print functions
+perror() {
+  printf "${COLOUR_SET_R}[-] ${COLOUR_END}%s\n" "$@" >&2
+  exit 1
+}
+
+pinfo() {
+  printf "${COLOUR_SET_B}[+] ${COLOUR_END}%s\n" "$@" >&2
+}
+
+paction() {
+  printf "${COLOUR_SET_G}[*] ${COLOUR_END}%s\n" "$@" >&2
+}
+
+# We assume that we're running inside vipatsar tree
+for dir in $(find . -not -path '*/.git/*' -not -path '.' -type d) ;
+do
+  # The port/library name is derived from the directory
+  port=${dir##./}
+  pinfo "Working on ${port}"
+  cd $dir
+  paction "Converting ${port}.json"
+  ../convert_vipakfile.sh -c "${port}.json"
+  pinfo "Conversion done"
+
+  cd - >/dev/null || return
+done

--- a/dbg.json
+++ b/dbg.json
@@ -2,16 +2,16 @@
   "Package": "dbg",
   "Author":  "noch",
   "License": "GPL-3",
-  "Version": "0.1",
+  "Version": "0.1.0",
   "Remote":
     {
     "type": "git",
     "path": "https://github.com/norayr/dbg",
-    "tag" : "0.1"
+    "tag" : "0.1.0"
     },
   "Dependencies":
   {
-    "strutils": "0.1"
+    "strutils": "0.1.0"
   },
   "Build":
   [

--- a/dbg.json
+++ b/dbg.json
@@ -1,20 +1,20 @@
 {
-  "Package": "dbg",
-  "Author":  "noch",
-  "License": "GPL-3",
-  "Version": "0.1.0",
-  "Remote":
-    {
+  "package": "dbg",
+  "author": "noch",
+  "license": "GPL-3",
+  "version": "0.1.0",
+  "remote": {
     "type": "git",
     "path": "https://github.com/norayr/dbg",
-    "tag" : "0.1.0"
-    },
-  "Dependencies":
-  {
+    "tag": "0.1.0"
+  },
+  "dependencies": {
     "strutils": "0.1.0"
   },
-  "Build":
-  [
-    {"command": "voc -s", "file": "src/dbg.Mod"}
+  "build": [
+    {
+      "command": "voc -s",
+      "file": "src/dbg.Mod"
+    }
   ]
 }

--- a/dbg/dbg-0.1.0.vipakfile
+++ b/dbg/dbg-0.1.0.vipakfile
@@ -1,0 +1,17 @@
+NAME      = dbg
+VERSION   = 0.1.0
+
+AUTHOR    = noch
+LICENSE   = GPL-3
+
+REMOTE    = git https://github.com/norayr/dbg 0.1.0
+
+DEPS      = strutils:0.1.0
+
+RUN       = 
+MAIN      = 
+BUILD     = voc -s src/dbg.Mod
+
+TEST_RUN  = 
+TEST_MAIN = 
+TEST      = 

--- a/diaspora.json
+++ b/diaspora.json
@@ -1,22 +1,25 @@
 {
-  "Package": "diaspora",
-  "Author":  "noch",
-  "License": "GPL-3",
-  "Version": "0.1.0",
-  "Remote":
-    {
+  "package": "diaspora",
+  "author": "noch",
+  "license": "GPL-3",
+  "version": "0.1.0",
+  "remote": {
     "type": "git",
     "path": "https://github.com/norayr/diaspora",
-    "tag" : "0.1.0"
-    },
-  "Dependencies":
-  {
+    "tag": "0.1.0"
+  },
+  "dependencies": {
     "lists": "0.1.0",
     "postgres": "0.1.0"
   },
-  "Build":
-  [
-    {"command": "voc -s", "file": "src/diasporadb.Mod"},
-    {"command": "voc -s", "file": "src/diasporaPost.Mod"}
+  "build": [
+    {
+      "command": "voc -s",
+      "file": "src/diasporadb.Mod"
+    },
+    {
+      "command": "voc -s",
+      "file": "src/diasporaPost.Mod"
+    }
   ]
 }

--- a/diaspora.json
+++ b/diaspora.json
@@ -2,17 +2,17 @@
   "Package": "diaspora",
   "Author":  "noch",
   "License": "GPL-3",
-  "Version": "0.1",
+  "Version": "0.1.0",
   "Remote":
     {
     "type": "git",
     "path": "https://github.com/norayr/diaspora",
-    "tag" : "0.1"
+    "tag" : "0.1.0"
     },
   "Dependencies":
   {
-    "lists": "0.1",
-    "postgres": "0.1"
+    "lists": "0.1.0",
+    "postgres": "0.1.0"
   },
   "Build":
   [

--- a/diaspora/diaspora-0.1.0.vipakfile
+++ b/diaspora/diaspora-0.1.0.vipakfile
@@ -1,0 +1,17 @@
+NAME      = diaspora
+VERSION   = 0.1.0
+
+AUTHOR    = noch
+LICENSE   = GPL-3
+
+REMOTE    = git https://github.com/norayr/diaspora 0.1.0
+
+DEPS      = lists:0.1.0 postgres:0.1.0
+
+RUN       = 
+MAIN      = 
+BUILD     = voc -s src/diasporadb.Mod;voc -s src/diasporaPost.Mod
+
+TEST_RUN  = 
+TEST_MAIN = 
+TEST      = 

--- a/etiquette.json
+++ b/etiquette.json
@@ -1,16 +1,17 @@
 {
-  "Package": "etiquette",
-  "Author":  "noch",
-  "License": "GPL-3",
-  "Version": "0.1.0",
-  "Remote":
-    {
+  "package": "etiquette",
+  "author": "noch",
+  "license": "GPL-3",
+  "version": "0.1.0",
+  "remote": {
     "type": "git",
     "path": "https://github.com/norayr/etiquette",
-    "tag" : "0.1.0"
-    },
-  "Build":
-  [
-    {"command": "voc -m", "file": "src/etiquette.Mod"}
+    "tag": "0.1.0"
+  },
+  "build": [
+    {
+      "command": "voc -m",
+      "file": "src/etiquette.Mod"
+    }
   ]
 }

--- a/etiquette.json
+++ b/etiquette.json
@@ -2,12 +2,12 @@
   "Package": "etiquette",
   "Author":  "noch",
   "License": "GPL-3",
-  "Version": "0.1",
+  "Version": "0.1.0",
   "Remote":
     {
     "type": "git",
     "path": "https://github.com/norayr/etiquette",
-    "tag" : "0.1"
+    "tag" : "0.1.0"
     },
   "Build":
   [

--- a/etiquette/etiquette-0.1.0.vipakfile
+++ b/etiquette/etiquette-0.1.0.vipakfile
@@ -1,0 +1,17 @@
+NAME      = etiquette
+VERSION   = 0.1.0
+
+AUTHOR    = noch
+LICENSE   = GPL-3
+
+REMOTE    = git https://github.com/norayr/etiquette 0.1.0
+
+DEPS      = 
+
+RUN       = 
+MAIN      = 
+BUILD     = voc -m src/etiquette.Mod
+
+TEST_RUN  = 
+TEST_MAIN = 
+TEST      = 

--- a/fifo.json
+++ b/fifo.json
@@ -1,16 +1,17 @@
 {
-  "Package": "fifo",
-  "Author":  "noch",
-  "License": "GPL-3",
-  "Version": "0.1.0",
-  "Remote":
-    {
+  "package": "fifo",
+  "author": "noch",
+  "license": "GPL-3",
+  "version": "0.1.0",
+  "remote": {
     "type": "git",
     "path": "https://github.com/norayr/fifo",
-    "tag" : "0.1.0"
-    },
-  "Build":
-  [
-    {"command": "voc -s", "file": "src/fifo.Mod"}
+    "tag": "0.1.0"
+  },
+  "build": [
+    {
+      "command": "voc -s",
+      "file": "src/fifo.Mod"
+    }
   ]
 }

--- a/fifo.json
+++ b/fifo.json
@@ -2,12 +2,12 @@
   "Package": "fifo",
   "Author":  "noch",
   "License": "GPL-3",
-  "Version": "0.1",
+  "Version": "0.1.0",
   "Remote":
     {
     "type": "git",
     "path": "https://github.com/norayr/fifo",
-    "tag" : "0.1"
+    "tag" : "0.1.0"
     },
   "Build":
   [

--- a/fifo/fifo-0.1.0.vipakfile
+++ b/fifo/fifo-0.1.0.vipakfile
@@ -1,0 +1,17 @@
+NAME      = fifo
+VERSION   = 0.1.0
+
+AUTHOR    = noch
+LICENSE   = GPL-3
+
+REMOTE    = git https://github.com/norayr/fifo 0.1.0
+
+DEPS      = 
+
+RUN       = 
+MAIN      = 
+BUILD     = voc -s src/fifo.Mod
+
+TEST_RUN  = 
+TEST_MAIN = 
+TEST      = 

--- a/http.json
+++ b/http.json
@@ -2,18 +2,18 @@
   "Package": "http",
   "Author":  "noch",
   "License": "GPL-3",
-  "Version": "0.1",
+  "Version": "0.1.0",
   "Remote":
     {
     "type": "git",
     "path": "https://github.com/norayr/http",
-    "tag" : "0.1"
+    "tag" : "0.1.0"
     },
   "Dependencies":
   {
-    "strutils": "0.1",
-    "base64": "0.1",
-    "Internet": "0.1"
+    "strutils": "0.1.0",
+    "base64": "0.1.0",
+    "Internet": "0.1.0"
   },
   "Build":
   [

--- a/http.json
+++ b/http.json
@@ -1,23 +1,26 @@
 {
-  "Package": "http",
-  "Author":  "noch",
-  "License": "GPL-3",
-  "Version": "0.1.0",
-  "Remote":
-    {
+  "package": "http",
+  "author": "noch",
+  "license": "GPL-3",
+  "version": "0.1.0",
+  "remote": {
     "type": "git",
     "path": "https://github.com/norayr/http",
-    "tag" : "0.1.0"
-    },
-  "Dependencies":
-  {
+    "tag": "0.1.0"
+  },
+  "dependencies": {
     "strutils": "0.1.0",
     "base64": "0.1.0",
-    "Internet": "0.1.0"
+    "internet": "0.1.0"
   },
-  "Build":
-  [
-     {"command": "voc -s", "file": "src/hexIntStr.Mod"},
-     {"command": "voc -s", "file": "src/http.Mod"}
+  "build": [
+    {
+      "command": "voc -s",
+      "file": "src/hexIntStr.Mod"
+    },
+    {
+      "command": "voc -s",
+      "file": "src/http.Mod"
+    }
   ]
 }

--- a/http/http-0.1.0.vipakfile
+++ b/http/http-0.1.0.vipakfile
@@ -6,7 +6,7 @@ LICENSE   = GPL-3
 
 REMOTE    = git https://github.com/norayr/http 0.1.0
 
-DEPS      = strutils:0.1.0 base64:0.1.0 Internet:0.1.0
+DEPS      = strutils:0.1.0 base64:0.1.0 internet:0.1.0
 
 RUN       = 
 MAIN      = 

--- a/http/http-0.1.0.vipakfile
+++ b/http/http-0.1.0.vipakfile
@@ -1,0 +1,17 @@
+NAME      = http
+VERSION   = 0.1.0
+
+AUTHOR    = noch
+LICENSE   = GPL-3
+
+REMOTE    = git https://github.com/norayr/http 0.1.0
+
+DEPS      = strutils:0.1.0 base64:0.1.0 Internet:0.1.0
+
+RUN       = 
+MAIN      = 
+BUILD     = voc -s src/hexIntStr.Mod;voc -s src/http.Mod
+
+TEST_RUN  = 
+TEST_MAIN = 
+TEST      = 

--- a/irc.json
+++ b/irc.json
@@ -2,19 +2,19 @@
   "Package": "irc",
   "Author":  "noch",
   "License": "GPL-3",
-  "Version": "0.1",
+  "Version": "0.1.0",
   "Remote":
     {
     "type": "git",
     "path": "https://github.com/norayr/irc",
-    "tag" : "0.1"
+    "tag" : "0.1.0"
     },
   "Dependencies":
   {
-    "time": "0.1",
-    "Internet": "0.1",
-    "lists": "0.1",
-    "dbg": "0.1"
+    "time": "0.1.0",
+    "Internet": "0.1.0",
+    "lists": "0.1.0",
+    "dbg": "0.1.0"
   },
   "Build":
   [

--- a/irc.json
+++ b/irc.json
@@ -1,23 +1,23 @@
 {
-  "Package": "irc",
-  "Author":  "noch",
-  "License": "GPL-3",
-  "Version": "0.1.0",
-  "Remote":
-    {
+  "package": "irc",
+  "author": "noch",
+  "license": "GPL-3",
+  "version": "0.1.0",
+  "remote": {
     "type": "git",
     "path": "https://github.com/norayr/irc",
-    "tag" : "0.1.0"
-    },
-  "Dependencies":
-  {
+    "tag": "0.1.0"
+  },
+  "dependencies": {
     "time": "0.1.0",
-    "Internet": "0.1.0",
+    "internet": "0.1.0",
     "lists": "0.1.0",
     "dbg": "0.1.0"
   },
-  "Build":
-  [
-     {"command": "voc -s", "file": "src/IRC.Mod"}
+  "build": [
+    {
+      "command": "voc -s",
+      "file": "src/IRC.Mod"
+    }
   ]
 }

--- a/irc/irc-0.1.0.vipakfile
+++ b/irc/irc-0.1.0.vipakfile
@@ -1,0 +1,17 @@
+NAME      = irc
+VERSION   = 0.1.0
+
+AUTHOR    = noch
+LICENSE   = GPL-3
+
+REMOTE    = git https://github.com/norayr/irc 0.1.0
+
+DEPS      = time:0.1.0 Internet:0.1.0 lists:0.1.0 dbg:0.1.0
+
+RUN       = 
+MAIN      = 
+BUILD     = voc -s src/IRC.Mod
+
+TEST_RUN  = 
+TEST_MAIN = 
+TEST      = 

--- a/irc/irc-0.1.0.vipakfile
+++ b/irc/irc-0.1.0.vipakfile
@@ -6,7 +6,7 @@ LICENSE   = GPL-3
 
 REMOTE    = git https://github.com/norayr/irc 0.1.0
 
-DEPS      = time:0.1.0 Internet:0.1.0 lists:0.1.0 dbg:0.1.0
+DEPS      = time:0.1.0 internet:0.1.0 lists:0.1.0 dbg:0.1.0
 
 RUN       = 
 MAIN      = 

--- a/irc_bot.json
+++ b/irc_bot.json
@@ -2,20 +2,20 @@
   "Package": "irc_bot",
   "Author":  "noch",
   "License": "GPL-3",
-  "Version": "0.1",
+  "Version": "0.1.0",
   "Remote":
     {
     "type": "git",
     "path": "https://github.com/norayr/irc_bot",
-    "tag" : "0.1"
+    "tag" : "0.1.0"
     },
   "Dependencies":
   {
-    "opts": "0.1",
-    "lists":"0.1",
-    "Internet": "0.1",
-    "time": "0.1",
-    "irc": "0.1"
+    "opts": "0.1.0",
+    "lists":"0.1.0",
+    "Internet": "0.1.0",
+    "time": "0.1.0",
+    "irc": "0.1.0"
   },
   "Build":
   [

--- a/irc_bot.json
+++ b/irc_bot.json
@@ -1,24 +1,24 @@
 {
-  "Package": "irc_bot",
-  "Author":  "noch",
-  "License": "GPL-3",
-  "Version": "0.1.0",
-  "Remote":
-    {
+  "package": "irc_bot",
+  "author": "noch",
+  "license": "GPL-3",
+  "version": "0.1.0",
+  "remote": {
     "type": "git",
     "path": "https://github.com/norayr/irc_bot",
-    "tag" : "0.1.0"
-    },
-  "Dependencies":
-  {
+    "tag": "0.1.0"
+  },
+  "dependencies": {
     "opts": "0.1.0",
-    "lists":"0.1.0",
-    "Internet": "0.1.0",
+    "lists": "0.1.0",
+    "internet": "0.1.0",
     "time": "0.1.0",
     "irc": "0.1.0"
   },
-  "Build":
-  [
-     {"command": "voc -m", "file": "src/vocbot.Mod"}
+  "build": [
+    {
+      "command": "voc -m",
+      "file": "src/vocbot.Mod"
+    }
   ]
 }

--- a/irc_bot/irc_bot-0.1.0.vipakfile
+++ b/irc_bot/irc_bot-0.1.0.vipakfile
@@ -1,0 +1,17 @@
+NAME      = irc_bot
+VERSION   = 0.1.0
+
+AUTHOR    = noch
+LICENSE   = GPL-3
+
+REMOTE    = git https://github.com/norayr/irc_bot 0.1.0
+
+DEPS      = opts:0.1.0 lists:0.1.0 Internet:0.1.0 time:0.1.0 irc:0.1.0
+
+RUN       = 
+MAIN      = 
+BUILD     = voc -m src/vocbot.Mod
+
+TEST_RUN  = 
+TEST_MAIN = 
+TEST      = 

--- a/irc_bot/irc_bot-0.1.0.vipakfile
+++ b/irc_bot/irc_bot-0.1.0.vipakfile
@@ -6,7 +6,7 @@ LICENSE   = GPL-3
 
 REMOTE    = git https://github.com/norayr/irc_bot 0.1.0
 
-DEPS      = opts:0.1.0 lists:0.1.0 Internet:0.1.0 time:0.1.0 irc:0.1.0
+DEPS      = opts:0.1.0 lists:0.1.0 internet:0.1.0 time:0.1.0 irc:0.1.0
 
 RUN       = 
 MAIN      = 

--- a/libucl.json
+++ b/libucl.json
@@ -1,18 +1,25 @@
 {
-  "Package": "libucl",
-  "Author":  "antranigv",
-  "License": "BSD",
-  "Version": "0.1.0",
-  "Remote":
-    {
+  "package": "libucl",
+  "author": "antranigv",
+  "license": "BSD",
+  "version": "0.1.0",
+  "remote": {
     "type": "git",
     "path": "https://github.com/antranigv/voclibucl",
-    "tag" : "0.1.0"
+    "tag": "0.1.0"
+  },
+  "build": [
+    {
+      "command": "voc -s",
+      "file": "src/ucl.Mod"
     },
-   "Build":
-   [
-     {"command": "voc -s", "file": "src/ucl.Mod"},
-     {"command": "CFLAGS=-lucl voc -m", "file": "test/libucl_test.Mod"},
-     {"command": "cp", "file": "test/example.ucl ."}
-   ]
+    {
+      "command": "CFLAGS=-lucl voc -m",
+      "file": "test/libucl_test.Mod"
+    },
+    {
+      "command": "cp",
+      "file": "test/example.ucl ."
+    }
+  ]
 }

--- a/libucl.json
+++ b/libucl.json
@@ -2,12 +2,12 @@
   "Package": "libucl",
   "Author":  "antranigv",
   "License": "BSD",
-  "Version": "0.1",
+  "Version": "0.1.0",
   "Remote":
     {
     "type": "git",
     "path": "https://github.com/antranigv/voclibucl",
-    "tag" : "0.1"
+    "tag" : "0.1.0"
     },
    "Build":
    [

--- a/libucl/libucl-0.1.0.vipakfile
+++ b/libucl/libucl-0.1.0.vipakfile
@@ -1,0 +1,17 @@
+NAME      = libucl
+VERSION   = 0.1.0
+
+AUTHOR    = antranigv
+LICENSE   = BSD
+
+REMOTE    = git https://github.com/antranigv/voclibucl 0.1.0
+
+DEPS      = 
+
+RUN       = 
+MAIN      = 
+BUILD     = voc -s src/ucl.Mod;CFLAGS=-lucl voc -m test/libucl_test.Mod;cp test/example.ucl .
+
+TEST_RUN  = 
+TEST_MAIN = 
+TEST      = 

--- a/libxo.json
+++ b/libxo.json
@@ -2,12 +2,12 @@
   "Package": "libxo",
   "Author":  "antranigv",
   "License": "BSD",
-  "Version": "0.1",
+  "Version": "0.1.0",
   "Remote":
     {
     "type": "git",
     "path": "https://github.com/antranigv/voclibxo",
-    "tag" : "0.1"
+    "tag" : "0.1.0"
     },
    "Build":
    [

--- a/libxo.json
+++ b/libxo.json
@@ -1,17 +1,21 @@
 {
-  "Package": "libxo",
-  "Author":  "antranigv",
-  "License": "BSD",
-  "Version": "0.1.0",
-  "Remote":
-    {
+  "package": "libxo",
+  "author": "antranigv",
+  "license": "BSD",
+  "version": "0.1.0",
+  "remote": {
     "type": "git",
     "path": "https://github.com/antranigv/voclibxo",
-    "tag" : "0.1.0"
+    "tag": "0.1.0"
+  },
+  "build": [
+    {
+      "command": "voc -s",
+      "file": "src/xo.Mod"
     },
-   "Build":
-   [
-     {"command": "voc -s", "file": "src/xo.Mod"},
-     {"command": "CFLAGS=-lxo voc -m", "file": "test/libxo_test.Mod"}
-   ]
+    {
+      "command": "CFLAGS=-lxo voc -m",
+      "file": "test/libxo_test.Mod"
+    }
+  ]
 }

--- a/libxo/libxo-0.1.0.vipakfile
+++ b/libxo/libxo-0.1.0.vipakfile
@@ -1,0 +1,17 @@
+NAME      = libxo
+VERSION   = 0.1.0
+
+AUTHOR    = antranigv
+LICENSE   = BSD
+
+REMOTE    = git https://github.com/antranigv/voclibxo 0.1.0
+
+DEPS      = 
+
+RUN       = 
+MAIN      = 
+BUILD     = voc -s src/xo.Mod;CFLAGS=-lxo voc -m test/libxo_test.Mod
+
+TEST_RUN  = 
+TEST_MAIN = 
+TEST      = 

--- a/lists.json
+++ b/lists.json
@@ -2,16 +2,16 @@
   "Package": "lists",
   "Author":  "noch",
   "License": "GPL-3",
-  "Version": "0.1",
+  "Version": "0.1.0",
   "Remote":
     {
     "type": "git",
     "path": "https://github.com/norayr/lists",
-    "tag" : "0.1"
+    "tag" : "0.1.0"
     },
   "Dependencies":
   {
-    "strutils": "0.1"
+    "strutils": "0.1.0"
   },
   "Build":
     [

--- a/lists.json
+++ b/lists.json
@@ -1,22 +1,28 @@
 {
-  "Package": "lists",
-  "Author":  "noch",
-  "License": "GPL-3",
-  "Version": "0.1.0",
-  "Remote":
-    {
+  "package": "lists",
+  "author": "noch",
+  "license": "GPL-3",
+  "version": "0.1.0",
+  "remote": {
     "type": "git",
     "path": "https://github.com/norayr/lists",
-    "tag" : "0.1.0"
-    },
-  "Dependencies":
-  {
+    "tag": "0.1.0"
+  },
+  "dependencies": {
     "strutils": "0.1.0"
   },
-  "Build":
-    [
-     {"command": "voc -s", "file": "src/List.Mod"},
-     {"command": "voc -s", "file": "src/StringList.Mod"},
-     {"command": "voc -m", "file": "test/testList.Mod"}
-    ]
+  "build": [
+    {
+      "command": "voc -s",
+      "file": "src/List.Mod"
+    },
+    {
+      "command": "voc -s",
+      "file": "src/StringList.Mod"
+    },
+    {
+      "command": "voc -m",
+      "file": "test/testList.Mod"
+    }
+  ]
 }

--- a/lists/lists-0.1.0.vipakfile
+++ b/lists/lists-0.1.0.vipakfile
@@ -1,0 +1,17 @@
+NAME      = lists
+VERSION   = 0.1.0
+
+AUTHOR    = noch
+LICENSE   = GPL-3
+
+REMOTE    = git https://github.com/norayr/lists 0.1.0
+
+DEPS      = strutils:0.1.0
+
+RUN       = 
+MAIN      = 
+BUILD     = voc -s src/List.Mod;voc -s src/StringList.Mod;voc -m test/testList.Mod
+
+TEST_RUN  = 
+TEST_MAIN = 
+TEST      = 

--- a/manush.json
+++ b/manush.json
@@ -1,32 +1,56 @@
 {
-  "Package": "manush",
-  "Author":  "noch",
-  "License": "BSD 2-Clause License",
-  "Version": "0.1.1",
-  "Remote":
-  {
+  "package": "manush",
+  "author": "noch",
+  "license": "BSD 2-Clause License",
+  "version": "0.1.1",
+  "remote": {
     "type": "git",
     "path": "https://github.com/illuria/manush",
     "branch": "master",
-    "tag" : "0.1"
+    "tag": "0.1"
   },
-  "Dependencies":
-  {
+  "dependencies": {
     "lists": "0.1",
     "opts": "0.1",
     "pipes": "0.1",
-    "skprJson": "0.1"
+    "skprjson": "0.1"
   },
-  "Build":
-  [
-    {"command": "voc -s", "file": "src/mnshList.Mod"},
-    {"command": "voc -s", "file": "src/mnshUnix.Mod"},
-    {"command": "voc -s", "file": "src/mnshDefs.Mod"},
-    {"command": "voc -s", "file": "src/mnshCrt.Mod"},
-    {"command": "voc -s", "file": "src/mnshStorage.Mod"},
-    {"command": "voc -s", "file": "src/mnshExtTools.Mod"},
-    {"command": "voc -s", "file": "src/mnshTerm.Mod"},
-    {"command": "voc -s", "file": "src/mnshInput.Mod"},
-    {"command": "voc -M", "file": "src/manush.Mod"}
+  "build": [
+    {
+      "command": "voc -s",
+      "file": "src/mnshList.Mod"
+    },
+    {
+      "command": "voc -s",
+      "file": "src/mnshUnix.Mod"
+    },
+    {
+      "command": "voc -s",
+      "file": "src/mnshDefs.Mod"
+    },
+    {
+      "command": "voc -s",
+      "file": "src/mnshCrt.Mod"
+    },
+    {
+      "command": "voc -s",
+      "file": "src/mnshStorage.Mod"
+    },
+    {
+      "command": "voc -s",
+      "file": "src/mnshExtTools.Mod"
+    },
+    {
+      "command": "voc -s",
+      "file": "src/mnshTerm.Mod"
+    },
+    {
+      "command": "voc -s",
+      "file": "src/mnshInput.Mod"
+    },
+    {
+      "command": "voc -M",
+      "file": "src/manush.Mod"
+    }
   ]
 }

--- a/manush/manush-0.1.1.vipakfile
+++ b/manush/manush-0.1.1.vipakfile
@@ -1,0 +1,17 @@
+NAME      = manush
+VERSION   = 0.1.1
+
+AUTHOR    = noch
+LICENSE   = BSD 2-Clause License
+
+REMOTE    = git https://github.com/illuria/manush 0.1
+
+DEPS      = lists:0.1 opts:0.1 pipes:0.1 skprJson:0.1
+
+RUN       = 
+MAIN      = 
+BUILD     = voc -s src/mnshList.Mod;voc -s src/mnshUnix.Mod;voc -s src/mnshDefs.Mod;voc -s src/mnshCrt.Mod;voc -s src/mnshStorage.Mod;voc -s src/mnshExtTools.Mod;voc -s src/mnshTerm.Mod;voc -s src/mnshInput.Mod;voc -M src/manush.Mod
+
+TEST_RUN  = 
+TEST_MAIN = 
+TEST      = 

--- a/manush/manush-0.1.1.vipakfile
+++ b/manush/manush-0.1.1.vipakfile
@@ -6,7 +6,7 @@ LICENSE   = BSD 2-Clause License
 
 REMOTE    = git https://github.com/illuria/manush 0.1
 
-DEPS      = lists:0.1 opts:0.1 pipes:0.1 skprJson:0.1
+DEPS      = lists:0.1 opts:0.1 pipes:0.1 skprjson:0.1
 
 RUN       = 
 MAIN      = 

--- a/oberonDS.json
+++ b/oberonDS.json
@@ -2,12 +2,12 @@
   "Package": "oberonDS",
   "Author":  "InnaKhachikyan",
   "License": "unknown",
-  "Version": "0.1",
+  "Version": "0.1.0",
   "Remote":
     {
     "type": "git",
     "path": "https://github.com/InnaKhachikyan/oberonDS",
-    "tag" : "0.1"
+    "tag" : "0.1.0"
     },
   "Build":
     [

--- a/oberonDS.json
+++ b/oberonDS.json
@@ -1,21 +1,37 @@
 {
-  "Package": "oberonDS",
-  "Author":  "InnaKhachikyan",
-  "License": "unknown",
-  "Version": "0.1.0",
-  "Remote":
-    {
+  "package": "oberonDS",
+  "author": "InnaKhachikyan",
+  "license": "unknown",
+  "version": "0.1.0",
+  "remote": {
     "type": "git",
     "path": "https://github.com/InnaKhachikyan/oberonDS",
-    "tag" : "0.1.0"
+    "tag": "0.1.0"
+  },
+  "build": [
+    {
+      "command": "voc -s",
+      "file": "src/DynamicArray.Mod"
     },
-  "Build":
-    [
-     {"command": "voc -s", "file": "src/DynamicArray.Mod"},
-     {"command": "voc -s", "file": "src/HashMap.Mod"},
-     {"command": "voc -s", "file": "src/Map.Mod"},
-     {"command": "voc -m", "file": "test/DynamicArrayTest.Mod"},
-     {"command": "voc -m", "file": "test/HashMapTest.Mod"},
-     {"command": "voc -m", "file":  "test/MapTest.Mod"}
-    ]
+    {
+      "command": "voc -s",
+      "file": "src/HashMap.Mod"
+    },
+    {
+      "command": "voc -s",
+      "file": "src/Map.Mod"
+    },
+    {
+      "command": "voc -m",
+      "file": "test/DynamicArrayTest.Mod"
+    },
+    {
+      "command": "voc -m",
+      "file": "test/HashMapTest.Mod"
+    },
+    {
+      "command": "voc -m",
+      "file": "test/MapTest.Mod"
+    }
+  ]
 }

--- a/oberonDS/oberonDS-0.1.0.vipakfile
+++ b/oberonDS/oberonDS-0.1.0.vipakfile
@@ -1,0 +1,17 @@
+NAME      = oberonDS
+VERSION   = 0.1.0
+
+AUTHOR    = InnaKhachikyan
+LICENSE   = unknown
+
+REMOTE    = git https://github.com/InnaKhachikyan/oberonDS 0.1.0
+
+DEPS      = 
+
+RUN       = 
+MAIN      = 
+BUILD     = voc -s src/DynamicArray.Mod;voc -s src/HashMap.Mod;voc -s src/Map.Mod;voc -m test/DynamicArrayTest.Mod;voc -m test/HashMapTest.Mod;voc -m test/MapTest.Mod
+
+TEST_RUN  = 
+TEST_MAIN = 
+TEST      = 

--- a/opts.json
+++ b/opts.json
@@ -1,22 +1,28 @@
 {
-  "Package": "opts",
-  "Author":  "noch",
-  "License": "GPL-3",
-  "Version": "0.1.0",
-  "Remote":
-    {
+  "package": "opts",
+  "author": "noch",
+  "license": "GPL-3",
+  "version": "0.1.0",
+  "remote": {
     "type": "git",
     "path": "https://github.com/norayr/opts",
-    "tag" : "0.1.0"
-    },
-  "Dependencies":
-  {
+    "tag": "0.1.0"
+  },
+  "dependencies": {
     "lists": "0.1.0"
   },
-  "Build":
-  [
-     {"command": "voc -s", "file": "src/optsos.Mod"},
-     {"command": "voc -s", "file": "src/opts.Mod"},
-     {"command": "voc -m", "file": "src/testopts.Mod"}
+  "build": [
+    {
+      "command": "voc -s",
+      "file": "src/optsos.Mod"
+    },
+    {
+      "command": "voc -s",
+      "file": "src/opts.Mod"
+    },
+    {
+      "command": "voc -m",
+      "file": "src/testopts.Mod"
+    }
   ]
 }

--- a/opts.json
+++ b/opts.json
@@ -2,16 +2,16 @@
   "Package": "opts",
   "Author":  "noch",
   "License": "GPL-3",
-  "Version": "0.1",
+  "Version": "0.1.0",
   "Remote":
     {
     "type": "git",
     "path": "https://github.com/norayr/opts",
-    "tag" : "0.1"
+    "tag" : "0.1.0"
     },
   "Dependencies":
   {
-    "lists": "0.1"
+    "lists": "0.1.0"
   },
   "Build":
   [

--- a/opts/opts-0.1.0.vipakfile
+++ b/opts/opts-0.1.0.vipakfile
@@ -1,0 +1,17 @@
+NAME      = opts
+VERSION   = 0.1.0
+
+AUTHOR    = noch
+LICENSE   = GPL-3
+
+REMOTE    = git https://github.com/norayr/opts 0.1.0
+
+DEPS      = lists:0.1.0
+
+RUN       = 
+MAIN      = 
+BUILD     = voc -s src/optsos.Mod;voc -s src/opts.Mod;voc -m src/testopts.Mod
+
+TEST_RUN  = 
+TEST_MAIN = 
+TEST      = 

--- a/pipes.json
+++ b/pipes.json
@@ -2,12 +2,12 @@
   "Package": "pipes",
   "Author":  "noch",
   "License": "GPL-3",
-  "Version": "0.1",
+  "Version": "0.1.0",
   "Remote":
     {
     "type": "git",
     "path": "https://github.com/norayr/pipes",
-    "tag" : "0.1"
+    "tag" : "0.1.0"
     },
   "Build":
     [

--- a/pipes.json
+++ b/pipes.json
@@ -1,17 +1,21 @@
 {
-  "Package": "pipes",
-  "Author":  "noch",
-  "License": "GPL-3",
-  "Version": "0.1.0",
-  "Remote":
-    {
+  "package": "pipes",
+  "author": "noch",
+  "license": "GPL-3",
+  "version": "0.1.0",
+  "remote": {
     "type": "git",
     "path": "https://github.com/norayr/pipes",
-    "tag" : "0.1.0"
+    "tag": "0.1.0"
+  },
+  "build": [
+    {
+      "command": "voc -s",
+      "file": "src/pipes.Mod"
     },
-  "Build":
-    [
-     {"command": "voc -s", "file": "src/pipes.Mod"},
-     {"command": "voc -m", "file": "src/testPipes.Mod"}
-    ]
+    {
+      "command": "voc -m",
+      "file": "src/testPipes.Mod"
+    }
+  ]
 }

--- a/pipes/pipes-0.1.0.vipakfile
+++ b/pipes/pipes-0.1.0.vipakfile
@@ -1,0 +1,17 @@
+NAME      = pipes
+VERSION   = 0.1.0
+
+AUTHOR    = noch
+LICENSE   = GPL-3
+
+REMOTE    = git https://github.com/norayr/pipes 0.1.0
+
+DEPS      = 
+
+RUN       = 
+MAIN      = 
+BUILD     = voc -s src/pipes.Mod;voc -m src/testPipes.Mod
+
+TEST_RUN  = 
+TEST_MAIN = 
+TEST      = 

--- a/postgres.json
+++ b/postgres.json
@@ -2,16 +2,16 @@
   "Package": "postgres",
   "Author":  "noch",
   "License": "GPL-3",
-  "Version": "0.1",
+  "Version": "0.1.0",
   "Remote":
     {
     "type": "git",
     "path": "https://github.com/norayr/postgres",
-    "tag" : "0.1"
+    "tag" : "0.1.0"
     },
    "Dependencies":
    {
-     "pipes": "0.1"
+     "pipes": "0.1.0"
    },
    "Build":
    [

--- a/postgres.json
+++ b/postgres.json
@@ -1,21 +1,24 @@
 {
-  "Package": "postgres",
-  "Author":  "noch",
-  "License": "GPL-3",
-  "Version": "0.1.0",
-  "Remote":
-    {
+  "package": "postgres",
+  "author": "noch",
+  "license": "GPL-3",
+  "version": "0.1.0",
+  "remote": {
     "type": "git",
     "path": "https://github.com/norayr/postgres",
-    "tag" : "0.1.0"
+    "tag": "0.1.0"
+  },
+  "dependencies": {
+    "pipes": "0.1.0"
+  },
+  "build": [
+    {
+      "command": "voc -s",
+      "file": "postgres.Mod"
     },
-   "Dependencies":
-   {
-     "pipes": "0.1.0"
-   },
-   "Build":
-   [
-    {"command": "voc -s", "file": "postgres.Mod"},
-    {"command": "voc -m", "file": "PostgresTests.Mod"}
-   ]
+    {
+      "command": "voc -m",
+      "file": "PostgresTests.Mod"
+    }
+  ]
 }

--- a/postgres/postgres-0.1.0.vipakfile
+++ b/postgres/postgres-0.1.0.vipakfile
@@ -1,0 +1,17 @@
+NAME      = postgres
+VERSION   = 0.1.0
+
+AUTHOR    = noch
+LICENSE   = GPL-3
+
+REMOTE    = git https://github.com/norayr/postgres 0.1.0
+
+DEPS      = pipes:0.1.0
+
+RUN       = 
+MAIN      = 
+BUILD     = voc -s postgres.Mod;voc -m PostgresTests.Mod
+
+TEST_RUN  = 
+TEST_MAIN = 
+TEST      = 

--- a/skprJson.json
+++ b/skprJson.json
@@ -2,17 +2,17 @@
   "Package": "skprJson",
   "Author":  "shekspir55",
   "License": "GPL-3",
-  "Version": "0.1",
+  "Version": "0.1.0",
   "Remote":
     {
     "type": "git",
     "path": "https://github.com/norayr/skprJson",
-    "tag" : "0.1"
+    "tag" : "0.1.0"
     },
   "Dependencies":
   {
-    "lists": "0.1",
-    "skprLogger": "0.1"
+    "lists": "0.1.0",
+    "skprLogger": "0.1.0"
   },
   "Build":
   [

--- a/skprJson.json
+++ b/skprJson.json
@@ -1,22 +1,25 @@
 {
-  "Package": "skprJson",
-  "Author":  "shekspir55",
-  "License": "GPL-3",
-  "Version": "0.1.0",
-  "Remote":
-    {
+  "package": "skprJson",
+  "author": "shekspir55",
+  "license": "GPL-3",
+  "version": "0.1.0",
+  "remote": {
     "type": "git",
     "path": "https://github.com/norayr/skprJson",
-    "tag" : "0.1.0"
-    },
-  "Dependencies":
-  {
-    "lists": "0.1.0",
-    "skprLogger": "0.1.0"
+    "tag": "0.1.0"
   },
-  "Build":
-  [
-     {"command": "voc -s", "file": "src/skprCharStack.Mod"},
-     {"command": "voc -s", "file": "src/skprJson.Mod"}
+  "dependencies": {
+    "lists": "0.1.0",
+    "skprlogger": "0.1.0"
+  },
+  "build": [
+    {
+      "command": "voc -s",
+      "file": "src/skprCharStack.Mod"
+    },
+    {
+      "command": "voc -s",
+      "file": "src/skprJson.Mod"
+    }
   ]
 }

--- a/skprJson/skprJson-0.1.0.vipakfile
+++ b/skprJson/skprJson-0.1.0.vipakfile
@@ -6,7 +6,7 @@ LICENSE   = GPL-3
 
 REMOTE    = git https://github.com/norayr/skprJson 0.1.0
 
-DEPS      = lists:0.1.0 skprLogger:0.1.0
+DEPS      = lists:0.1.0 skprlogger:0.1.0
 
 RUN       = 
 MAIN      = 

--- a/skprJson/skprJson-0.1.0.vipakfile
+++ b/skprJson/skprJson-0.1.0.vipakfile
@@ -1,0 +1,17 @@
+NAME      = skprJson
+VERSION   = 0.1.0
+
+AUTHOR    = shekspir55
+LICENSE   = GPL-3
+
+REMOTE    = git https://github.com/norayr/skprJson 0.1.0
+
+DEPS      = lists:0.1.0 skprLogger:0.1.0
+
+RUN       = 
+MAIN      = 
+BUILD     = voc -s src/skprCharStack.Mod;voc -s src/skprJson.Mod
+
+TEST_RUN  = 
+TEST_MAIN = 
+TEST      = 

--- a/skprLogger.json
+++ b/skprLogger.json
@@ -1,20 +1,20 @@
 {
-  "Package": "skprLogger",
-  "Author":  "shekspir55",
-  "License": "GPL-3",
-  "Version": "0.1.0",
-  "Remote":
-    {
+  "package": "skprLogger",
+  "author": "shekspir55",
+  "license": "GPL-3",
+  "version": "0.1.0",
+  "remote": {
     "type": "git",
     "path": "https://github.com/norayr/skprLogger",
-    "tag" : "0.1.0"
-    },
-  "Dependencies":
-  {
+    "tag": "0.1.0"
+  },
+  "dependencies": {
     "time": "0.1.0"
   },
-  "Build":
-  [
-     {"command": "voc -s", "file": "src/skprLogger.Mod"}
+  "build": [
+    {
+      "command": "voc -s",
+      "file": "src/skprLogger.Mod"
+    }
   ]
 }

--- a/skprLogger.json
+++ b/skprLogger.json
@@ -2,16 +2,16 @@
   "Package": "skprLogger",
   "Author":  "shekspir55",
   "License": "GPL-3",
-  "Version": "0.1",
+  "Version": "0.1.0",
   "Remote":
     {
     "type": "git",
     "path": "https://github.com/norayr/skprLogger",
-    "tag" : "0.1"
+    "tag" : "0.1.0"
     },
   "Dependencies":
   {
-    "time": "0.1"
+    "time": "0.1.0"
   },
   "Build":
   [

--- a/skprLogger/skprLogger-0.1.0.vipakfile
+++ b/skprLogger/skprLogger-0.1.0.vipakfile
@@ -1,0 +1,17 @@
+NAME      = skprLogger
+VERSION   = 0.1.0
+
+AUTHOR    = shekspir55
+LICENSE   = GPL-3
+
+REMOTE    = git https://github.com/norayr/skprLogger 0.1.0
+
+DEPS      = time:0.1.0
+
+RUN       = 
+MAIN      = 
+BUILD     = voc -s src/skprLogger.Mod
+
+TEST_RUN  = 
+TEST_MAIN = 
+TEST      = 

--- a/strutils.json
+++ b/strutils.json
@@ -2,12 +2,12 @@
   "Package": "strutils",
   "Author":  "noch",
   "License": "GPL-3",
-  "Version": "0.1",
+  "Version": "0.1.0",
   "Remote":
     {
     "type": "git",
     "path": "https://github.com/norayr/strutils",
-    "tag" : "0.1"
+    "tag" : "0.1.0"
     },
   "Build":
     [

--- a/strutils.json
+++ b/strutils.json
@@ -1,18 +1,25 @@
 {
-  "Package": "strutils",
-  "Author":  "noch",
-  "License": "GPL-3",
-  "Version": "0.1.0",
-  "Remote":
-    {
+  "package": "strutils",
+  "author": "noch",
+  "license": "GPL-3",
+  "version": "0.1.0",
+  "remote": {
     "type": "git",
     "path": "https://github.com/norayr/strutils",
-    "tag" : "0.1.0"
+    "tag": "0.1.0"
+  },
+  "build": [
+    {
+      "command": "voc -s",
+      "file": "src/strTypes.Mod"
     },
-  "Build":
-    [
-     {"command": "voc -s", "file": "src/strTypes.Mod"},
-     {"command": "voc -s", "file": "src/strUtils.Mod"},
-     {"command": "voc -m", "file": "test/testStrUtils.Mod"}
-    ]
+    {
+      "command": "voc -s",
+      "file": "src/strUtils.Mod"
+    },
+    {
+      "command": "voc -m",
+      "file": "test/testStrUtils.Mod"
+    }
+  ]
 }

--- a/strutils/strutils-0.1.0.vipakfile
+++ b/strutils/strutils-0.1.0.vipakfile
@@ -1,0 +1,17 @@
+NAME      = strutils
+VERSION   = 0.1.0
+
+AUTHOR    = noch
+LICENSE   = GPL-3
+
+REMOTE    = git https://github.com/norayr/strutils 0.1.0
+
+DEPS      = 
+
+RUN       = 
+MAIN      = 
+BUILD     = voc -s src/strTypes.Mod;voc -s src/strUtils.Mod;voc -m test/testStrUtils.Mod
+
+TEST_RUN  = 
+TEST_MAIN = 
+TEST      = 

--- a/strutils2.json
+++ b/strutils2.json
@@ -1,28 +1,39 @@
 {
-  "Package": "strutils2",
-  "Author":  "noch",
-  "License": "GPL-3",
-  "Version": "0.1.0",
-  "Remote": {
-      "Type": "https",
-      "Files": [
-           {
-             "URL": "https://norayr.am/vpk/strutils/src/strTypes.Mod",
-             "AuthType": "BasicAuth",
-             "AuthCredentials": {"User": "tactun", "Password": "tactun"},
-             "MD5": "3d3a2782bb5d244824fe2fe7bd214f74"
-           },
-        {
-           "URL": "https://norayr.am/vpk/strutils/src/strUtils.Mod",
-           "AuthType": "BasicAuth",
-           "AuthCredentials": {"User": "tactun", "Password": "tactun"},
-           "MD5": "43146f0d62473f2ac05b327792ec1258"
-        }
-      ]
-     },
-  "Build":
-    [
-     {"Command": "voc -s", "File": "strTypes.Mod"},
-     {"Command": "voc -s", "File": "strUtils.Mod"}
+  "package": "strutils2",
+  "author": "noch",
+  "license": "GPL-3",
+  "version": "0.1.0",
+  "remote": {
+    "type": "https",
+    "files": [
+      {
+        "url": "https://norayr.am/vpk/strutils/src/strTypes.Mod",
+        "authtype": "BasicAuth",
+        "authcredentials": {
+          "user": "tactun",
+          "password": "tactun"
+        },
+        "md5": "3d3a2782bb5d244824fe2fe7bd214f74"
+      },
+      {
+        "url": "https://norayr.am/vpk/strutils/src/strUtils.Mod",
+        "authtype": "BasicAuth",
+        "authcredentials": {
+          "user": "tactun",
+          "password": "tactun"
+        },
+        "md5": "43146f0d62473f2ac05b327792ec1258"
+      }
     ]
+  },
+  "build": [
+    {
+      "command": "voc -s",
+      "file": "strTypes.Mod"
+    },
+    {
+      "command": "voc -s",
+      "file": "strUtils.Mod"
+    }
+  ]
 }

--- a/strutils2.json
+++ b/strutils2.json
@@ -2,7 +2,7 @@
   "Package": "strutils2",
   "Author":  "noch",
   "License": "GPL-3",
-  "Version": "0.1",
+  "Version": "0.1.0",
   "Remote": {
       "Type": "https",
       "Files": [

--- a/strutils2/strutils2-0.1.0.vipakfile
+++ b/strutils2/strutils2-0.1.0.vipakfile
@@ -1,0 +1,17 @@
+NAME      = strutils2
+VERSION   = 0.1.0
+
+AUTHOR    = noch
+LICENSE   = GPL-3
+
+REMOTE    = 
+
+DEPS      = 
+
+RUN       = 
+MAIN      = 
+BUILD     =  ; 
+
+TEST_RUN  = 
+TEST_MAIN = 
+TEST      = 

--- a/strutils2/strutils2-0.1.0.vipakfile
+++ b/strutils2/strutils2-0.1.0.vipakfile
@@ -4,13 +4,13 @@ VERSION   = 0.1.0
 AUTHOR    = noch
 LICENSE   = GPL-3
 
-REMOTE    = 
+REMOTE    = https https://tactun:tactun@norayr.am/vpk/strutils/src/strTypes.Mod md5,3d3a2782bb5d244824fe2fe7bd214f74;https://tactun:tactun@norayr.am/vpk/strutils/src/strUtils.Mod md5,43146f0d62473f2ac05b327792ec1258
 
 DEPS      = 
 
 RUN       = 
 MAIN      = 
-BUILD     =  ; 
+BUILD     = voc -s strTypes.Mod;voc -s strUtils.Mod
 
 TEST_RUN  = 
 TEST_MAIN = 

--- a/test_server.json
+++ b/test_server.json
@@ -2,19 +2,19 @@
   "Package": "test_server",
   "Author":  "noch",
   "License": "GPL-3",
-  "Version": "0.1",
+  "Version": "0.1.0",
   "Remote":
     {
     "type": "git",
     "path": "https://github.com/norayr/test_server",
-    "tag" : "0.1"
+    "tag" : "0.1.0"
     },
   "Dependencies":
   {
-    "lists": "0.1",
-    "Internet":"0.1",
-    "time": "0.1",
-    "fifo": "0.1"
+    "lists": "0.1.0",
+    "Internet":"0.1.0",
+    "time": "0.1.0",
+    "fifo": "0.1.0"
   },
   "Build":
   [

--- a/test_server.json
+++ b/test_server.json
@@ -1,24 +1,27 @@
 {
-  "Package": "test_server",
-  "Author":  "noch",
-  "License": "GPL-3",
-  "Version": "0.1.0",
-  "Remote":
-    {
+  "package": "test_server",
+  "author": "noch",
+  "license": "GPL-3",
+  "version": "0.1.0",
+  "remote": {
     "type": "git",
     "path": "https://github.com/norayr/test_server",
-    "tag" : "0.1.0"
-    },
-  "Dependencies":
-  {
+    "tag": "0.1.0"
+  },
+  "dependencies": {
     "lists": "0.1.0",
-    "Internet":"0.1.0",
+    "internet": "0.1.0",
     "time": "0.1.0",
     "fifo": "0.1.0"
   },
-  "Build":
-  [
-     {"command": "voc -m", "file": "src/testServer.Mod"},
-     {"command": "voc -m", "file": "src/testClient.Mod"}
+  "build": [
+    {
+      "command": "voc -m",
+      "file": "src/testServer.Mod"
+    },
+    {
+      "command": "voc -m",
+      "file": "src/testClient.Mod"
+    }
   ]
 }

--- a/test_server/test_server-0.1.0.vipakfile
+++ b/test_server/test_server-0.1.0.vipakfile
@@ -1,0 +1,17 @@
+NAME      = test_server
+VERSION   = 0.1.0
+
+AUTHOR    = noch
+LICENSE   = GPL-3
+
+REMOTE    = git https://github.com/norayr/test_server 0.1.0
+
+DEPS      = lists:0.1.0 Internet:0.1.0 time:0.1.0 fifo:0.1.0
+
+RUN       = 
+MAIN      = 
+BUILD     = voc -m src/testServer.Mod;voc -m src/testClient.Mod
+
+TEST_RUN  = 
+TEST_MAIN = 
+TEST      = 

--- a/test_server/test_server-0.1.0.vipakfile
+++ b/test_server/test_server-0.1.0.vipakfile
@@ -6,7 +6,7 @@ LICENSE   = GPL-3
 
 REMOTE    = git https://github.com/norayr/test_server 0.1.0
 
-DEPS      = lists:0.1.0 Internet:0.1.0 time:0.1.0 fifo:0.1.0
+DEPS      = lists:0.1.0 internet:0.1.0 time:0.1.0 fifo:0.1.0
 
 RUN       = 
 MAIN      = 

--- a/time.json
+++ b/time.json
@@ -2,12 +2,12 @@
   "Package": "time",
   "Author":  "noch",
   "License": "GPL-3",
-  "Version": "0.1",
+  "Version": "0.1.0",
   "Remote":
     {
     "type": "git",
     "path": "https://github.com/norayr/time",
-    "tag" : "0.1"
+    "tag" : "0.1.0"
     },
   "Build":
   [

--- a/time.json
+++ b/time.json
@@ -1,16 +1,17 @@
 {
-  "Package": "time",
-  "Author":  "noch",
-  "License": "GPL-3",
-  "Version": "0.1.0",
-  "Remote":
-    {
+  "package": "time",
+  "author": "noch",
+  "license": "GPL-3",
+  "version": "0.1.0",
+  "remote": {
     "type": "git",
     "path": "https://github.com/norayr/time",
-    "tag" : "0.1.0"
-    },
-  "Build":
-  [
-    {"command": "voc -s", "file": "src/time.Mod"}
+    "tag": "0.1.0"
+  },
+  "build": [
+    {
+      "command": "voc -s",
+      "file": "src/time.Mod"
+    }
   ]
 }

--- a/time/time-0.1.0.vipakfile
+++ b/time/time-0.1.0.vipakfile
@@ -1,0 +1,17 @@
+NAME      = time
+VERSION   = 0.1.0
+
+AUTHOR    = noch
+LICENSE   = GPL-3
+
+REMOTE    = git https://github.com/norayr/time 0.1.0
+
+DEPS      = 
+
+RUN       = 
+MAIN      = 
+BUILD     = voc -s src/time.Mod
+
+TEST_RUN  = 
+TEST_MAIN = 
+TEST      = 

--- a/unixFileSystem.json
+++ b/unixFileSystem.json
@@ -2,12 +2,12 @@
   "Package": "unixFileSystem",
   "Author":  "noch",
   "License": "GPL-3",
-  "Version": "0.1",
+  "Version": "0.1.0",
   "Remote":
     {
     "type": "git",
     "path": "https://github.com/norayr/unixFileSystem",
-    "tag" : "0.1"
+    "tag" : "0.1.0"
     },
   "Build":
   [

--- a/unixFileSystem.json
+++ b/unixFileSystem.json
@@ -1,17 +1,21 @@
 {
-  "Package": "unixFileSystem",
-  "Author":  "noch",
-  "License": "GPL-3",
-  "Version": "0.1.0",
-  "Remote":
-    {
+  "package": "unixFileSystem",
+  "author": "noch",
+  "license": "GPL-3",
+  "version": "0.1.0",
+  "remote": {
     "type": "git",
     "path": "https://github.com/norayr/unixFileSystem",
-    "tag" : "0.1.0"
+    "tag": "0.1.0"
+  },
+  "build": [
+    {
+      "command": "voc -s",
+      "file": "src/UnixFS.Mod"
     },
-  "Build":
-  [
-    {"command": "voc -s", "file": "src/UnixFS.Mod"},
-    {"command": "voc -m", "file": "test/TestUnixFS.Mod"}
+    {
+      "command": "voc -m",
+      "file": "test/TestUnixFS.Mod"
+    }
   ]
 }

--- a/unixFileSystem/unixFileSystem-0.1.0.vipakfile
+++ b/unixFileSystem/unixFileSystem-0.1.0.vipakfile
@@ -1,0 +1,17 @@
+NAME      = unixFileSystem
+VERSION   = 0.1.0
+
+AUTHOR    = noch
+LICENSE   = GPL-3
+
+REMOTE    = git https://github.com/norayr/unixFileSystem 0.1.0
+
+DEPS      = 
+
+RUN       = 
+MAIN      = 
+BUILD     = voc -s src/UnixFS.Mod;voc -m test/TestUnixFS.Mod
+
+TEST_RUN  = 
+TEST_MAIN = 
+TEST      = 

--- a/unixfs.json
+++ b/unixfs.json
@@ -2,12 +2,12 @@
   "Package": "unixfs",
   "Author":  "noch",
   "License": "GPL-3",
-  "Version": "0.1",
+  "Version": "0.1.0",
   "Remote":
     {
     "type": "git",
     "path": "https://github.com/norayr/unixfs",
-    "tag" : "0.1"
+    "tag" : "0.1.0"
     },
   "Build":
   [

--- a/unixfs.json
+++ b/unixfs.json
@@ -1,16 +1,17 @@
 {
-  "Package": "unixfs",
-  "Author":  "noch",
-  "License": "GPL-3",
-  "Version": "0.1.0",
-  "Remote":
-    {
+  "package": "unixfs",
+  "author": "noch",
+  "license": "GPL-3",
+  "version": "0.1.0",
+  "remote": {
     "type": "git",
     "path": "https://github.com/norayr/unixfs",
-    "tag" : "0.1.0"
-    },
-  "Build":
-  [
-    {"command": "voc -s", "file": "src/unixFiles.Mod"}
+    "tag": "0.1.0"
+  },
+  "build": [
+    {
+      "command": "voc -s",
+      "file": "src/unixFiles.Mod"
+    }
   ]
 }

--- a/unixfs/unixfs-0.1.0.vipakfile
+++ b/unixfs/unixfs-0.1.0.vipakfile
@@ -1,0 +1,17 @@
+NAME      = unixfs
+VERSION   = 0.1.0
+
+AUTHOR    = noch
+LICENSE   = GPL-3
+
+REMOTE    = git https://github.com/norayr/unixfs 0.1.0
+
+DEPS      = 
+
+RUN       = 
+MAIN      = 
+BUILD     = voc -s src/unixFiles.Mod
+
+TEST_RUN  = 
+TEST_MAIN = 
+TEST      = 

--- a/vpicl.json
+++ b/vpicl.json
@@ -1,19 +1,29 @@
 {
-  "Package": "vpicl",
-  "Author":  "noch",
-  "License": "GPL-3",
-  "Version": "0.1.0",
-  "Remote":
-    {
+  "package": "vpicl",
+  "author": "noch",
+  "license": "GPL-3",
+  "version": "0.1.0",
+  "remote": {
     "type": "git",
     "path": "https://github.com/norayr/vpicl",
-    "tag" : "0.1.0"
+    "tag": "0.1.0"
+  },
+  "build": [
+    {
+      "command": "voc -s",
+      "file": "POutput.Mod"
     },
-  "Build":
-  [
-    {"command": "voc -s", "file": "POutput.Mod"},
-    {"command": "voc -s", "file": "PErrors.Mod"},
-    {"command": "voc -s", "file": "PICS.Mod"},
-    {"command": "voc -m", "file": "PICL.Mod"}
+    {
+      "command": "voc -s",
+      "file": "PErrors.Mod"
+    },
+    {
+      "command": "voc -s",
+      "file": "PICS.Mod"
+    },
+    {
+      "command": "voc -m",
+      "file": "PICL.Mod"
+    }
   ]
 }

--- a/vpicl.json
+++ b/vpicl.json
@@ -2,12 +2,12 @@
   "Package": "vpicl",
   "Author":  "noch",
   "License": "GPL-3",
-  "Version": "0.1",
+  "Version": "0.1.0",
   "Remote":
     {
     "type": "git",
     "path": "https://github.com/norayr/vpicl",
-    "tag" : "0.1"
+    "tag" : "0.1.0"
     },
   "Build":
   [

--- a/vpicl/vpicl-0.1.0.vipakfile
+++ b/vpicl/vpicl-0.1.0.vipakfile
@@ -1,0 +1,17 @@
+NAME      = vpicl
+VERSION   = 0.1.0
+
+AUTHOR    = noch
+LICENSE   = GPL-3
+
+REMOTE    = git https://github.com/norayr/vpicl 0.1.0
+
+DEPS      = 
+
+RUN       = 
+MAIN      = 
+BUILD     = voc -s POutput.Mod;voc -s PErrors.Mod;voc -s PICS.Mod;voc -m PICL.Mod
+
+TEST_RUN  = 
+TEST_MAIN = 
+TEST      = 

--- a/xattr.json
+++ b/xattr.json
@@ -2,12 +2,12 @@
   "Package": "xattr",
   "Author":  "noch",
   "License": "GPL-3",
-  "Version": "0.1",
+  "Version": "0.1.0",
   "Remote":
     {
     "type": "git",
     "path": "https://github.com/norayr/xattr",
-    "tag" : "0.1"
+    "tag" : "0.1.0"
     },
   "Build":
   [

--- a/xattr.json
+++ b/xattr.json
@@ -1,16 +1,17 @@
 {
-  "Package": "xattr",
-  "Author":  "noch",
-  "License": "GPL-3",
-  "Version": "0.1.0",
-  "Remote":
-    {
+  "package": "xattr",
+  "author": "noch",
+  "license": "GPL-3",
+  "version": "0.1.0",
+  "remote": {
     "type": "git",
     "path": "https://github.com/norayr/xattr",
-    "tag" : "0.1.0"
-    },
-  "Build":
-  [
-    {"command": "voc -s", "file": "src/xattr.Mod"}
+    "tag": "0.1.0"
+  },
+  "build": [
+    {
+      "command": "voc -s",
+      "file": "src/xattr.Mod"
+    }
   ]
 }

--- a/xattr/xattr-0.1.0.vipakfile
+++ b/xattr/xattr-0.1.0.vipakfile
@@ -1,0 +1,17 @@
+NAME      = xattr
+VERSION   = 0.1.0
+
+AUTHOR    = noch
+LICENSE   = GPL-3
+
+REMOTE    = git https://github.com/norayr/xattr 0.1.0
+
+DEPS      = 
+
+RUN       = 
+MAIN      = 
+BUILD     = voc -s src/xattr.Mod
+
+TEST_RUN  = 
+TEST_MAIN = 
+TEST      = 


### PR DESCRIPTION
- To keep things consistent, all keys have been converted to lowercase using the Shell tool `to_lower.sh`
- All JSON package definitions now have their corresponding Vipakfile in a directory (with versioning)
- `convert_vipakfile.sh` converts a JSON to vipakfile
- `convert_vipatsar.sh` uses the tool above to convert the whole tree

Finally, there were some minor issues, such as duplicate package names, which have been resolves.

This change does not break the way current Vipak operates, however, it does allow `vix` and future Vipak to continue their development.